### PR TITLE
mods_feat(More Crafting Tables for Forge!): 新增更多工作台 v4.2.0

### DIFF
--- a/MultiVersions/Forge/main/mctb/lang/en_us.json
+++ b/MultiVersions/Forge/main/mctb/lang/en_us.json
@@ -1,0 +1,29 @@
+{
+  "block.minecraft.crafting_table": "Oak Crafting Table",
+
+  "block.mctb.spruce_crafting_table": "Spruce Crafting Table",
+  "block.mctb.birch_crafting_table": "Birch Crafting Table",
+  "block.mctb.jungle_crafting_table": "Jungle Crafting Table",
+  "block.mctb.acacia_crafting_table": "Acacia Crafting Table",
+  "block.mctb.dark_oak_crafting_table": "Dark Oak Crafting Table",
+  "block.mctb.warped_crafting_table": "Warped Crafting Table",
+  "block.mctb.crimson_crafting_table": "Crimson Crafting Table",
+  "block.mctb.mangrove_crafting_table": "Mangrove Crafting Table",
+
+  "block.mctb.cherry_crafting_table": "Cherry Crafting Table",
+  "block.mctb.dead_crafting_table": "Dead Crafting Table",
+  "block.mctb.fir_crafting_table": "Fir Crafting Table",
+  "block.mctb.hellbark_crafting_table": "Hellbark Crafting Table",
+  "block.mctb.jacaranda_crafting_table": "Jacaranda Crafting Table",
+  "block.mctb.magic_crafting_table": "Magic Crafting Table",
+  "block.mctb.mahogany_crafting_table": "Mahogany Crafting Table",
+  "block.mctb.palm_crafting_table": "Palm Crafting Table",
+  "block.mctb.redwood_crafting_table": "Redwood Crafting Table",
+  "block.mctb.umbran_crafting_table": "Umbran Crafting Table",
+  "block.mctb.willow_crafting_table": "Willow Crafting Table",
+
+  "block.mctb.azalea_crafting_table": "Azalea Crafting Table",
+  "block.mctb.blossom_crafting_table": "Blossom Crafting Table",
+
+  "container.crafting_table": "Crafting"
+}

--- a/MultiVersions/Forge/main/mctb/lang/zh_tw.json
+++ b/MultiVersions/Forge/main/mctb/lang/zh_tw.json
@@ -1,0 +1,29 @@
+{
+  "block.minecraft.crafting_table": "工作台",
+
+  "block.mctb.spruce_crafting_table": "杉木工作台",
+  "block.mctb.birch_crafting_table": "樺木工作台",
+  "block.mctb.jungle_crafting_table": "叢林木工作台",
+  "block.mctb.acacia_crafting_table": "相思木工作台",
+  "block.mctb.dark_oak_crafting_table": "黑橡木工作台",
+  "block.mctb.warped_crafting_table": "扭曲蕈木工作台",
+  "block.mctb.crimson_crafting_table": "緋紅蕈木工作台",
+  "block.mctb.mangrove_crafting_table": "紅樹林木工作台",
+
+  "block.mctb.cherry_crafting_table": "櫻桃木工作台",
+  "block.mctb.dead_crafting_table": "垂死木工作台",
+  "block.mctb.fir_crafting_table": "冷杉木工作台",
+  "block.mctb.hellbark_crafting_table": "地獄皮木工作台",
+  "block.mctb.jacaranda_crafting_table": "藍花楹木工作台",
+  "block.mctb.magic_crafting_table": "魔法木工作台",
+  "block.mctb.mahogany_crafting_table": "桃花心木工作台",
+  "block.mctb.palm_crafting_table": "棕櫚木工作台",
+  "block.mctb.redwood_crafting_table": "紅杉木工作台",
+  "block.mctb.umbran_crafting_table": "暗影木工作台",
+  "block.mctb.willow_crafting_table": "柳木工作台",
+
+  "block.mctb.azalea_crafting_table": "杜鵑木工作台",
+  "block.mctb.blossom_crafting_table": "繁花木工作台",
+
+  "container.crafting_table": "合成"
+}


### PR DESCRIPTION
`"block.minecraft.crafting_table": "Oak Crafting Table",` 維持原版翻譯「工作台」。

在有安裝該模組的模組包中，會改用補丁形式翻譯為「橡木工作台」。